### PR TITLE
remove pwd buffer

### DIFF
--- a/sources/builtins/pwd/ft_pwd.c
+++ b/sources/builtins/pwd/ft_pwd.c
@@ -20,15 +20,15 @@
  */
 int	pwd(char **cmd)
 {
-	char	*pwd;
+	char	*working_directory;
 
 	if (cmd[1] == NULL)
 	{
-		pwd = getcwd(NULL, 0);
-		if (pwd == NULL)
+		working_directory = getcwd(NULL, 0);
+		if (working_directory == NULL)
 			return (-1);
-		printf("%s\n", pwd);
-		free(pwd);
+		printf("%s\n", working_directory);
+		free(working_directory);
 		return (0);
 	}
 	else

--- a/sources/builtins/pwd/ft_pwd.c
+++ b/sources/builtins/pwd/ft_pwd.c
@@ -20,13 +20,15 @@
  */
 int	pwd(char **cmd)
 {
-	char	cwd[1024];
+	char	*pwd;
 
 	if (cmd[1] == NULL)
 	{
-		if (getcwd(cwd, sizeof(cwd)) == NULL)
+		pwd = getcwd(NULL, 0);
+		if (pwd == NULL)
 			return (-1);
-		printf("%s\n", cwd);
+		printf("%s\n", pwd);
+		free(pwd);
 		return (0);
 	}
 	else


### PR DESCRIPTION
As  an extension to the POSIX.1-2001 standard, glibc's getcwd() allocates the buffer dynamically using malloc(3) if buf is NULL.  In this case, the allocated buffer has the length size unless size is zero, when buf is allocated as big as necessary.  The caller should free(3) the returned buffer.

GL HF les bros ;)